### PR TITLE
build(UTF-8): Added support to enforce UTF-8 in builds #102

### DIFF
--- a/DECIDE/build.gradle
+++ b/DECIDE/build.gradle
@@ -17,3 +17,8 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+
+compileJava.options.encoding = 'UTF-8'
+compileJava {
+    options.forkOptions.jvmArgs = ['-Dfile.encoding=UTF-8']
+}


### PR DESCRIPTION
**Why this change:** Part of #102 because the examiners build was failed due to UTF-8 issue

**What has changed:**  In build.gradle, enforces the build execution to be in UTF-8